### PR TITLE
Moved DefaultCredentialOptions to Infra and basic deletion of Blob storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,4 @@ FodyWeavers.xsd
 /src/dotnet/DocApi/appsettings.json
 /src/dotnet/DocApi/appsettings.Development.json
 /src/dotnet/DocUploadHelper/appsettings.Development.json
+/src/dotnet/DocumentCleanUp/local.settings.json


### PR DESCRIPTION
Reuse credential options and delete a file from blob (BlobDocumentStore implementation)